### PR TITLE
Versão mínima do PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Requisitos
 ----------
 ---
  - [Magento] Community 1.5.x, 1.6.x, 1.7.x, 1.8.0.0
- - [PHP] 5.1.6+
+ - [PHP] 5.3.3+
  - [SPL]
  - [cURL]
  - [DOM]


### PR DESCRIPTION
Exjstem certos elementos utilizados no módulo que só estão disponíveis a partir da versão 5.3 do PHP, [exemplo](https://github.com/pagseguro/magento/blob/2f3d9dc0961dba57067a91bfd9384e9e6ba54a8b/app/code/local/PagSeguro/PagSeguro/Model/NotificationMethod.php#L23).
