### PR TITLE
Update Updates.php

### DIFF
--- a/app/code/local/PagSeguro/PagSeguro/Model/Updates.php
+++ b/app/code/local/PagSeguro/PagSeguro/Model/Updates.php
@@ -26,7 +26,7 @@ class Updates
             if (!is_null($collection)) {
                 $collection->getSelect()->joinLeft(
                     $table_prefix . 'pagseguro_sales_code',
-                    'main_table.entity_id = pagseguro_sales_code.order_id',
+                    'main_table.entity_id = '.$table_prefix.'pagseguro_sales_code.order_id',
                     array('transaction_code')
                 );
             }


### PR DESCRIPTION
Na igualdade de valores o $table_prefix foi esquecido gerando um "report" do Magento no momento da de visualização de pedidos.
Magento 1.9.1
Linha 29
