### PR TITLE
HSBC Bank Removal

### DIFF
--- a/lib/PagSeguroLibrary/domain/PagSeguroPaymentMethodCode.class.php
+++ b/lib/PagSeguroLibrary/domain/PagSeguroPaymentMethodCode.class.php
@@ -137,10 +137,6 @@ class PagSeguroPaymentMethodCode
          */
         'BANRISUL_ONLINE_TRANSFER' => 306,
         /***
-         * HSBC on-line transfer
-         */
-        'HSBC_ONLINE_TRANSFER' => 307,
-        /***
          * PagSeguro account balance
          */
         'PS_BALANCE' => 401,


### PR DESCRIPTION
HSBC ceased to exist in Brazil, now it is Bradesco.