### PR TITLE
Problema com venda de Produto Virtual

### DIFF
--- a/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
+++ b/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
@@ -45,6 +45,10 @@ class UOL_PagSeguro_Model_OrderAddress
      */
     private function setAddress(Mage_Sales_Model_Order_Address $address)
     {
+        if(empty($address)){
+			$address = $this->billingAddress;
+		}
+        
         $response = new \PagSeguro\Domains\Address();
         $parse = $this->parseStreet($address->getStreet1());
         $response->setStreet($parse['street']);

--- a/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
+++ b/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
@@ -47,8 +47,7 @@ class UOL_PagSeguro_Model_OrderAddress
     {
         if(empty($address)){
 			$address = $this->billingAddress;
-		}
-        
+		}        
         $response = new \PagSeguro\Domains\Address();
         $parse = $this->parseStreet($address->getStreet1());
         $response->setStreet($parse['street']);


### PR DESCRIPTION
Olá.

Tive um problema quando instalei o Pagseguro em uma loja de um cliente, onde este cliente vende apenas Produtos Virtuais, ou seja, que não possuem endereço de entrega. Desta forma, ao final do checkout, ao finalizar, a função payment() em PaymentMethod.php estava tentando definir o endereço de entrega usando $payment->setShipping(), quando no pedido não possui endereço de entrega.

Pensei em mudar algumas coisas para identificar o tipo de produto que está sendo vendido, porem, achei mais fácil se em  OrderAddress.php colocasse apenas:

`if(empty($address)){`
`$address = $this->billingAddress;`
`}`

No inicio da função: setAddress(). Dessa forma, seria o mesmo que dizer se o endereço de entrega estiver vazio, use o endereço de cobrança, pois sempre será requisitado para qualquer tipo de produto.

Obrigado desde já.