### PR TITLE
Problema na venda de Produto Virtual

### DIFF
--- a/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
+++ b/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
@@ -45,6 +45,10 @@ class UOL_PagSeguro_Model_OrderAddress
      */
     private function setAddress(Mage_Sales_Model_Order_Address $address)
     {
+        if(empty($address)){
+			$address = $this->billingAddress;
+		}
+        
         $response = new \PagSeguro\Domains\Address();
         $parse = $this->parseStreet($address->getStreet1());
         $response->setStreet($parse['street']);

--- a/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
+++ b/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
@@ -58,6 +58,7 @@ class UOL_PagSeguro_Model_OrderAddress
         $response->setState($this->getRegionAbbreviation($address));
         $response->setCountry($address->getCountry());
         $response->setComplement($address->getStreet3());
+        $response->setTelephone($address->getTelephone());
 
         return $response;
     }

--- a/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
+++ b/app/code/community/UOL/PagSeguro/Model/OrderAddress.php
@@ -47,8 +47,7 @@ class UOL_PagSeguro_Model_OrderAddress
     {
         if(empty($address)){
 			$address = $this->billingAddress;
-		}
-        
+		}        
         $response = new \PagSeguro\Domains\Address();
         $parse = $this->parseStreet($address->getStreet1());
         $response->setStreet($parse['street']);

--- a/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
+++ b/app/code/community/UOL/PagSeguro/Model/PaymentMethod.php
@@ -113,12 +113,16 @@ class UOL_PagSeguro_Model_PaymentMethod extends Mage_Payment_Model_Method_Abstra
         $payment->setReference(Mage::getStoreConfig('uol_pagseguro/store/reference').$this->order->getId());
         $payment->setCurrency('BRL');
         $this->setItems($payment);
+        $orderAddress = new UOL_PagSeguro_Model_OrderAddress($this->order);
+        $address = $orderAddress->getShippingAddress();
+        if(empty($address)){
+			$address = $orderAddress->getBillingAddress();	
+		}
         $payment->setSender()->setName($this->order->getCustomerName());
         $payment->setSender()->setEmail($this->order->getCustomerEmail());
-        $phone = $this->helper->formatPhone($this->order->getShippingAddress()->getTelephone());
+        $phone = $this->helper->formatPhone($address->getTelephone());
         $payment->setSender()->setPhone()->withParameters($phone['areaCode'], $phone['number']);
-        $orderAddress = new UOL_PagSeguro_Model_OrderAddress($this->order);
-        $payment->setShipping()->setAddress()->instance($orderAddress->getShippingAddress());
+        $payment->setShipping()->setAddress()->instance($address);
         $payment->setShipping()->setType()->withParameters(SHIPPING_TYPE);
         $payment->setShipping()->setCost()->withParameters(number_format($this->order->getShippingAmount(), 2, '.',
             ''));

--- a/lib/PagseguroPhpSdk/source/Domains/Address.php
+++ b/lib/PagseguroPhpSdk/source/Domains/Address.php
@@ -62,7 +62,10 @@ class Address
      * @var
      */
     private $country;
-
+    /**
+     * @var
+     */
+    private $telephone;
     /**
      * @return string
      */
@@ -204,6 +207,16 @@ class Address
     public function setStreet($street)
     {
         $this->street = $street;
+        return $this;
+    }
+    
+    /**
+     * @param $telephone
+     * @return $this
+     */
+    public function setTelephone($telephone)
+    {
+        $this->telephone = $telephone;
         return $this;
     }
 }


### PR DESCRIPTION
Olá.

Ao tentar fazer a venda de um produto virtual, que no caso não possui endereço de entrega, tive vários problemas, então tive que fazer algumas modificações para que o módulo pudesse atender a necessidade do meu cliente.

Resumindo, quando o pedido não tiver endereço de entrega, ele define o endereço de cobrança como padrão, já que este endereço é requisitado em qualquer tipo de produto, no checkout.

Obrigado desde já.